### PR TITLE
Get completion info via $criteria->review()

### DIFF
--- a/lang/de/format_progresstopics.php
+++ b/lang/de/format_progresstopics.php
@@ -31,4 +31,3 @@ $string['showfromothers'] = 'Abschnitt anzeigen';
 $string['privacy:metadata'] = 'Das Progressformat Plugin speichert keine personenbezogenen Daten.';
 
 $string['additionalrequirementswarning'] = 'Es gibt weitere Vorraussetzungen zum abschließen dieses Kurses';
-$string['progresspendingwarning'] = 'Einige Abgaben müssen noch verarbeitet werden, der Fortschritt kann daher unvollständig angezeigt werden';

--- a/lang/en/format_progresstopics.php
+++ b/lang/en/format_progresstopics.php
@@ -40,5 +40,4 @@ $string['privacy:metadata'] = 'The Topics format plugin does not store any perso
 
 // mustache warnings
 $string['additionalrequirementswarning'] = 'there are additional requirements to finish this course';
-$string['progresspendingwarning'] = 'Some completion data is still pending, the completion status may be inaccurate';
 

--- a/renderer.php
+++ b/renderer.php
@@ -67,16 +67,15 @@ class format_progresstopics_renderer extends format_topics_renderer {
         $completions = $completioninfo->get_completions($USER->id);
         $activities = $completioninfo->get_activities();
         $sectiondata = [];
-        $pending = false;
         $additionalrequirements = false;
         foreach ($completions as $task) {
             $criteria = $task->get_criteria();
-            if ($criteria->is_pending($task)) {
-                $pending = true;
-            }
             $ct = $criteria->criteriatype;
             if ($ct == COMPLETION_CRITERIA_TYPE_ACTIVITY) {
-                $completed = $task->is_complete();
+                $completed = $criteria->review($task, false);
+                if (!isset($activities[$criteria->moduleinstance])) {
+                    continue;
+                }
                 $sectionindex = intval($activities[intval($criteria->moduleinstance)]->sectionnum);
                 if (!array_key_exists($sectionindex, $sectiondata)) {
                     $sectioninfo = $info->get_section_info($sectionindex);
@@ -124,7 +123,6 @@ class format_progresstopics_renderer extends format_topics_renderer {
 
         $templatecontext["progress-sections"] = $progresssections;
         $templatecontext['additionalrequirements'] = $additionalrequirements;
-        $templatecontext['pendingupdate'] = $pending;
 
         echo $this->render_from_template('course/../format/progresstopics/templates/progressbox', $templatecontext); // Ugly hack.
     }

--- a/templates/progressbox.mustache
+++ b/templates/progressbox.mustache
@@ -33,9 +33,6 @@
     }
 }}
 
-{{#pendingupdate}}
-    <span class="progresspendingwarning">{{#str}}progresspendingwarning, format_progresstopics{{/str}}</span> <br>
-{{/pendingupdate}}
 {{#additionalrequirements}}
     <span class="progresswarning">{{# str}}additionalrequirementswarning, format_progresstopics{{/str}}</span> <br>
 {{/additionalrequirements}}


### PR DESCRIPTION
Fixes #17 
Looking at `$criteria->is_pending($task)`, it uses  `$criteria->review($task, false)` to get the actual up-to-date completion info, so it seems like a good idea, to just rely of `review()` to get the completion info. (It also changes when a user removes a completion mark).

Also, Fixes #19 